### PR TITLE
fix summaries for two endpoints

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -743,7 +743,7 @@ paths:
 
   /addresses/{address_hash}/token-balances:
     get:
-      summary: get blocks validated by address
+      summary: get address token balances
       operationId: get_address_token_balances
       parameters:
         - $ref: "#/components/parameters/addressHash"
@@ -761,7 +761,7 @@ paths:
 
   /addresses/{address_hash}/tokens:
     get:
-      summary: get blocks validated by address
+      summary: get address tokens by token type
       operationId: get_address_tokens
       parameters:
         - $ref: "#/components/parameters/addressHash"


### PR DESCRIPTION
Fix summaries for below endpoints:
* /addresses/{address_hash}/token-balances
summary: get address token balances
* /addresses/{address_hash}/tokens
summary: get address tokens by token type