### PR TITLE
Add cspell config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,20 @@
+name: Blockscout API v2 swagger
+
+on:
+  pull_request:
+  types: [opened, synchronize, reopened, labeled]
+  branches:
+    - main
+
+jobs:
+  cspell:
+    name: Check spelling
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run cspell
+        uses: streetsidesoftware/cspell-action@v6
+        with:
+          use_cspell_files: true
+          incremental_files_only: false

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,39 @@
+// cSpell Settings
+{
+    "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+    // Version of the setting file.  Always 0.2
+    "version": "0.6",
+    // language - current active spelling language
+    "language": "en",
+    // enabled - enable code editor suggestions
+    "enabled": true,
+    // useGitignore - use .gitignore to exclude files from checking
+    "useGitignore": true,
+    "ignoreRegExpList": [
+        // Ignore filecoin f410f-like native addresses
+        "f410f[a-z2-7]{39}"
+    ],
+    // words - list of words to be always considered correct
+    "words": [
+        "blockscout",
+        "BSWRF",
+        "bytecodes",
+        "Cryptostamp",
+        "decompiled",
+        "devdoc",
+        "filecoin",
+        "googlerpc",
+        "ipfs",
+        "linkreferences",
+        "multicall",
+        "poap",
+        "recaptcha",
+        "remappings",
+        "Resteaking",
+        "sourcify",
+        "subtraces",
+        "userdoc",
+        "xdai",
+        "watchlist"
+    ]
+}


### PR DESCRIPTION
This pull request introduces a new spelling check workflow using the `cspell` tool and configures it to run on specific events. It also includes a configuration file for `cspell` to define custom spelling rules and exceptions.

### New spelling check workflow:

* [`.github/config.yml`](diffhunk://#diff-1c346ca118b7a97918d27b97cffc9a996e5863c337e25f3136f6f131cb21f105R1-R20): Added a GitHub Actions workflow to check spelling using `cspell` on pull request events.

### Configuration for `cspell`:

* [`cspell.json`](diffhunk://#diff-77519f787fe7e051a14c588f101d61e4d8f0d3b01bf8e16cb65d3838243d4e68R1-R39): Added a configuration file for `cspell` with custom settings, including a list of words to be considered correct and a regular expression to ignore specific patterns.