### PR TITLE
Add nullable: true for multiple properties

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2102,6 +2102,7 @@ components:
           type: string
           example: "1866.51"
         to:
+          nullable: true,
           $ref: "#/components/schemas/AddressParam"
         transaction_burnt_fee:
           type: string
@@ -2146,6 +2147,7 @@ components:
           type: string
           example: "41309"
         created_contract:
+          nullable: true,
           $ref: "#/components/schemas/AddressParam"
         position:
           type: integer

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3417,6 +3417,7 @@ components:
           example: "1.0"
         indexed_internal_transactions_ratio:
           type: string
+          nullable: true
           example: "1.0"
 
     StatsResponse:


### PR DESCRIPTION
This pull request includes changes to the `swagger.yaml` file to allow certain fields to be nullable, improving the flexibility of the API schema.

Key changes include:

* `components:` section in `swagger.yaml`:
  * Made the `to` field nullable.
  * Made the `created_contract` field nullable.
  * Made the `indexed_internal_transactions_ratio` field nullable.