### PR TITLE
TokenTransfer: update `log_index` field to be integer

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1749,7 +1749,6 @@ components:
         - block_hash
         - from
         - log_index
-        - method
         - timestamp
         - to
         - token

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1749,7 +1749,6 @@ components:
         - block_hash
         - from
         - log_index
-        - timestamp
         - to
         - token
         - total

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1763,8 +1763,8 @@ components:
         from:
           $ref: "#/components/schemas/AddressParam"
         log_index:
-          type: string
-          example: "243"
+          type: integer
+          example: 16
         method:
           type: string
           example: "transfer"


### PR DESCRIPTION
Example: https://base.blockscout.com/api/v2/transactions/0xdd878faf22d0f8e7f3bce69f6a6d7f9f0c42442e01e65b3a24157020b97f72ce