### PR TITLE
chore: remove `is_vyper_contract` from the `/api/v2/smart-contracts/{address_hash}` endpoint response

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3100,8 +3100,6 @@ components:
           type: boolean
         is_verified_via_eth_bytecode_db:
           type: boolean
-        is_vyper_contract:
-          type: boolean
         is_self_destructed:
           type: boolean
         can_be_visualized_via_sol2uml:


### PR DESCRIPTION
https://github.com/blockscout/blockscout/pull/11823