### PR TITLE
chore: remove `is_self_destructed` field in `/api/v2/smart-contracts/{address_hash}` response

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3044,12 +3044,6 @@ components:
           type: boolean
         is_verified_via_eth_bytecode_db:
           type: boolean
-<<<<<<< Updated upstream
-        is_self_destructed:
-=======
-        is_vyper_contract:
->>>>>>> Stashed changes
-          type: boolean
         can_be_visualized_via_sol2uml:
           type: boolean
         minimal_proxy_address_hash:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2944,7 +2944,11 @@ components:
           type: boolean
         is_verified_via_eth_bytecode_db:
           type: boolean
+<<<<<<< Updated upstream
         is_self_destructed:
+=======
+        is_vyper_contract:
+>>>>>>> Stashed changes
           type: boolean
         can_be_visualized_via_sol2uml:
           type: boolean


### PR DESCRIPTION
related to https://github.com/blockscout/blockscout/pull/12239