### PR TITLE
Rollback default server

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,14 +3,10 @@ tags:
   - name: default
   - name: CelestiaService
 servers:
-  - url: https://eth.blockscout.com/api/v2/
-    description: Ethereum mainnet
-  - url: https://optimism.blockscout.com/api/v2/
-    description: Optimism mainnet
-  - url: https://base.blockscout.com/api/v2/
-    description: Base mainnet
-  - url: https://eth-sepolia.blockscout.com/api/v2/
-    description: Ethereum testnet  
+  - url: http://{server}/api/v2/
+    variables:
+      server:
+        default: eth.blockscout.com
 
 info:
   description: API for BlockScout web app


### PR DESCRIPTION
This pull request updates the `swagger.yaml` configuration to improve server flexibility by introducing a variable-based server URL. This change enables easier switching between different environments and networks.

API configuration update:

* Replaced the previous hardcoded server URLs for Ethereum mainnet, Optimism mainnet, Base mainnet, and Ethereum testnet with a single variable-based server URL (`http://{server}/api/v2/`), allowing dynamic selection of the server endpoint.